### PR TITLE
Allow partial imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,15 +113,15 @@ function keysSorter(input) {
 	return input;
 }
 
-exports.extract = function (str) {
+function extract(str) {
 	var queryStart = str.indexOf('?');
 	if (queryStart === -1) {
 		return '';
 	}
 	return str.slice(queryStart + 1);
-};
+}
 
-exports.parse = function (str, opts) {
+function parse(str, opts) {
 	opts = objectAssign({arrayFormat: 'none'}, opts);
 
 	var formatter = parserForArrayFormat(opts);
@@ -165,7 +165,10 @@ exports.parse = function (str, opts) {
 
 		return result;
 	}, Object.create(null));
-};
+}
+
+exports.extract = extract;
+exports.parse = parse;
 
 exports.stringify = function (obj, opts) {
 	var defaults = {
@@ -216,6 +219,6 @@ exports.stringify = function (obj, opts) {
 exports.parseUrl = function (str, opts) {
 	return {
 		url: str.split('?')[0] || '',
-		query: this.parse(this.extract(str), opts)
+		query: parse(extract(str), opts)
 	};
 };


### PR DESCRIPTION
`this.parse(this.extract(str), opts)` assumes `query-string` will always be imported fully. Importing `stringify` by itself works, but not `parseUrl`. This change makes the `parseUrl` export independent, allowing `import { parseUrl } from 'query-string'` and a more consistent behavior.